### PR TITLE
Use ng-template instead of deprecated template

### DIFF
--- a/src/ng2-ip/ng2-ip.component.html
+++ b/src/ng2-ip/ng2-ip.component.html
@@ -1,6 +1,6 @@
 <div class="ng2-ip-container" [ngClass]="containerClass">
   <div class="ng2-ip-table" [@inputAnim]="inputAnim">
-    <template ngFor let-idx [ngForOf]="blocksRef"; let-isLast="last">
+    <ng-template ngFor let-idx [ngForOf]="blocksRef"; let-isLast="last">
       <div class="ng2-ip-table-cell" [class.ng2-ip-disabled]="disabledBlocks[idx]" [ngClass]="invalidBlocks[idx]">
         <input #input
                type="text"
@@ -15,7 +15,7 @@
                (keyup)="onKeyUp($event, idx)"/>
       </div>
       <span class="ng2-ip-table-cell ng2-ip-sep" *ngIf="!isLast">{{vX.SEP}}</span>
-    </template>
+    </ng-template>
   </div>
 
   <div class="ng2-ip-copy-overlay" *ngIf="showCopySelection">


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Uses ng-template instead of deprecated template element


* **What is the current behavior?** (You can also link to an open issue here)

A warning is thrown when the module is used:

```
The <template> element is deprecated. Use <ng-template> instead ("ip-container"[ngClass]="containerClass">
  <div class="ng2-ip-table" [@inputAnim]="inputAnim">
    [WARNING ->]<template ngFor let-idx [ngForOf]="blocksRef"; let-isLast="last">
      <div class="ng2-ip-table-cell"): ng:///Ng2IpModule/Ng2IpComponent.html@3:4`
```

* **What is the new behavior (if this is a feature change)?**

No more warning is given

* **Other information**:
